### PR TITLE
Added cURL fetcher

### DIFF
--- a/steam/SteamGame.php
+++ b/steam/SteamGame.php
@@ -1,11 +1,14 @@
 <?php
+// Use SteamUtility to fetch URLs and other stuff
+require_once 'SteamUtility.php';
+
 /**
 * SteamGame - Representation of any Steam title on the Store
 *
 * @category   SteamAPI
 * @copyright  Copyright (c) 2012 Matt Ryder (www.mattryder.co.uk)
 * @license    GPLv2 License
-* @version    v1.1
+* @version    v1.2
 * @link       https://github.com/MattRyder/SteamAPI/blob/master/steam/SteamGame.php
 * @since      Class available since v1.0
 */
@@ -45,7 +48,7 @@ class SteamGame {
 			$base = "http://api.steampowered.com/ISteamNews/GetNewsForApp/v0002/"
 			      . "?appid={$this->appID}&count={$newsItemCount}&maxlength={$maxLength}&format=xml";
 
-			$newsData = new SimpleXMLElement(file_get_contents($base));
+			$newsData = new SimpleXMLElement(SteamUtility::fetchURL($base));
 
 			$i = 0;
 			$this->gameNews = array();
@@ -78,7 +81,7 @@ class SteamGame {
 			$base = "http://api.steampowered.com/ISteamUserStats/GetSchemaForGame/v0002/?key={$this->apiKey}&appid={$this->appID}&l={$lang}";
 		}
 
-		$json = file_get_contents($base);
+		$json = SteamUtility::fetchURL($base);
 		if(!$json) {
 			return null;
 		}

--- a/steam/SteamUser.php
+++ b/steam/SteamUser.php
@@ -1,6 +1,8 @@
 <?php
 // Disable XML warnings to avoid problems when SteamCommunity is down
 libxml_use_internal_errors(true);
+// Use SteamUtility to fetch URLs and other stuff
+require_once 'SteamUtility.php';
 
 /**
 * SteamUser - Representation of any Steam user profile
@@ -8,13 +10,12 @@ libxml_use_internal_errors(true);
 * @category   SteamAPI
 * @copyright  Copyright (c) 2012 Matt Ryder (www.mattryder.co.uk)
 * @license    GPLv2 License
-* @version    v1.1
+* @version    v1.2
 * @link       https://github.com/MattRyder/SteamAPI/blob/master/steam/SteamUser.php
 * @since      Class available since v1.0
 */
 class SteamUser {
 
-	private $connectTimeout = 2; // 2 seconds
 	private $userID;
 	private $vanityURL;
 	private $apiKey;
@@ -58,11 +59,7 @@ class SteamUser {
 		}
 
 		try {
-			$ctx = stream_context_create(array(
-				'http' => array(
-					'timeout' => $this->connectTimeout
-			)));
-			$content = file_get_contents($base, false, $ctx);
+			$content = SteamUtility::fetchURL($base);
 			if ($content) {
 				$parsedData = new SimpleXMLElement($content);
 			} else {
@@ -188,7 +185,7 @@ class SteamUser {
 			$baseURL = "http://api.steampowered.com/ISteamUser/GetFriendList/v0001/"
 			         . "?key={$apikey}&steamid={$this->steamID64}&relationship=friend&format=xml";
 
-			$parsedFL = new SimpleXMLElement(file_get_contents($baseURL));
+			$parsedFL = new SimpleXMLElement(SteamUtility::fetchURL($baseURL));
 			$this->friendList = array();
 
 			$i = 0;
@@ -219,11 +216,7 @@ class SteamUser {
 		}
 
 		try {
-			$ctx = stream_context_create(array(
-				'http' => array(
-					'timeout' => $this->connectTimeout
-			)));
-			$content = file_get_contents($base, false, $ctx);
+			$content = SteamUtility::fetchURL($base);
 			if ($content) {
 				$gamesData = new SimpleXMLElement($content);
 			} else {
@@ -267,11 +260,7 @@ class SteamUser {
 		}
 
 		try {
-			$ctx = stream_context_create(array(
-				'http' => array(
-					'timeout' => $this->connectTimeout
-			)));
-			$content = file_get_contents($base, false, $ctx);
+			$content = SteamUtility::fetchURL($base);
 			if ($content) {
 				$gameStats = new SimpleXMLElement($content);
 			} else {

--- a/steam/SteamUtility.php
+++ b/steam/SteamUtility.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+* SteamUtility - Utilities used by other Steam classes
+*
+* @category   SteamAPI
+* @copyright  Copyright (c) 2012 Matt Ryder (www.mattryder.co.uk)
+* @license    GPLv2 License
+* @version    v1.2
+* @link       https://github.com/MattRyder/SteamAPI/blob/master/steam/SteamUtility.php
+* @since      Class available since v1.2
+*/
+class SteamUtility {
+
+	public static $connectTimeout = 2; // 2 seconds
+
+	/**
+	 * Fetches content of a given URL via HTTP GET method.
+	 * @param  string $url Target URL
+	 * @return string      Response content or FALSE on error
+	 */
+	public static function fetchURL($url)
+	{
+		if (self::iniGetBool('allow_url_fopen'))
+		{
+			$ctx = stream_context_create(array(
+				'http' => array(
+					'timeout' => self::$connectTimeout
+			)));
+			return file_get_contents($url, false, $ctx);
+		}
+		elseif (function_exists('curl_init'))
+		{
+			$handle = curl_init();
+			curl_setopt($handle, CURLOPT_URL, $url);
+			curl_setopt($handle, CURLOPT_RETURNTRANSFER, true);
+			curl_setopt($handle, CURLOPT_TIMEOUT, self::$connectTimeout);
+			return curl_exec($handle);
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	/**
+	 * Returns boolean value of a php.ini setting
+	 * @param  string  $ini_name Setting name
+	 * @return boolean           Setting value
+	 */
+	private static function iniGetBool($ini_name) {
+		$ini_value = ini_get($ini_name);
+
+		switch (strtolower($ini_value))
+		{
+			case 'on':
+			case 'yes':
+			case 'true':
+				return 'assert.active' !== $ini_name;
+
+			case 'stdout':
+			case 'stderr':
+				return 'display_errors' === $ini_name;
+
+			default:
+				return (bool) (int) $ini_value;
+		}
+	}
+}


### PR DESCRIPTION
It's me again and our users have discovered that SteamAPI didn't work on hosts with `allow_url_fopen = Off` in php.ini. So I made a new version that uses cURL for such hosts (if available).
